### PR TITLE
Git support

### DIFF
--- a/paver/git.py
+++ b/paver/git.py
@@ -14,6 +14,9 @@ def _format_path(provided_path):
     else:
         return os.getcwd()
 
+def _split_remote_branch_name(provided_name):
+    return provided_name.split("/")[1]
+
 def clone(url, dest_folder):
     sh("git clone %(url)s %(path)s" % dict(url=url, path=dest_folder) )
 
@@ -81,3 +84,12 @@ def branch_checkout(branch_name, path=""):
     sh( "cd %(repo_path)s; git checkout %(branch_name)s" % dict(
         repo_path = _format_path(path),
         branch_name=branch_name) )
+     
+def branch_track_remote(remote_branch_name, local_branch_name=None, path=""):
+    local_branch_name = ( local_branch_name or _split_remote_branch_name(remote_branch_name) )
+    
+    sh( "cd %(repo_path)s; git checkout -b %(branch_name)s --track %(remote_branch_name)s" % dict(
+        repo_path = _format_path(path),
+        branch_name=local_branch_name,
+        remote_branch_name=remote_branch_name) )
+    

--- a/paver/tests/test_git.py
+++ b/paver/tests/test_git.py
@@ -32,12 +32,6 @@ def test_branch_chekout_cwd(sh):
     )
     
 @patch(git, "sh")
-def test_branch_list(sh):
-    git.branch_list(path="repo_path")
-    assert sh.called
-    assert sh.call_args[0][0] == "cd repo_path; git branch"
-    
-@patch(git, "sh")
 def test_branch_list_correctly_parses_git_output(sh):
     output = git.branch_list(path="repo_path", __override__="""
 * git_support
@@ -46,3 +40,25 @@ def test_branch_list_correctly_parses_git_output(sh):
     """)
     
     assert output == ("git_support", ["git_support", "master", "virtualenv_in_folder"])
+    
+@patch(git, "sh")
+def test_branch_list_correctly_parses_remote_branch_output(sh):
+    output = git.branch_list(path="repo_path", 
+        remote_branches_only = True,
+        __override__="""
+    github/gh-pages
+    github/git_support
+    github/master""")
+    
+    assert output == ('',
+        ["github/gh-pages", "github/git_support", "github/master"])
+
+@patch(git, "sh")
+def test_branch_track_remote(sh):
+    git.branch_track_remote("origin/alpha_two", path="repo_path")
+    
+    assert sh.called
+    assert sh.call_args[0][0] == "cd %(current_path)s; git checkout -b alpha_two --track origin/alpha_two" % dict(
+        current_path="repo_path"
+    )
+     


### PR DESCRIPTION
In the spirit of the SVN and BZR support we currently have in Paver, I've added Git support too.

In one way it's elementary: it can clone, list branches (local and remote), and checkout local and remote branches. It doesn't go beyond those basics (then again, neither does the svn support)
