### PR TITLE
This is hopefully a fix for issue '65.

### DIFF
--- a/paver/virtual.py
+++ b/paver/virtual.py
@@ -19,9 +19,13 @@ def _create_bootstrap(script_name, packages_to_install, paver_command_line,
     else:
         paver_install = ""
 
-    options = ""
-    if no_site_packages:
-        options = "    options.no_site_packages = True"
+    options = """
+
+    options.no_site_packages = %s
+    if hasattr(options,"system_site_packages"):
+        options.system_site_packages = %s
+        """%(bool(no_site_packages),not bool(no_site_packages))
+
     if unzip_setuptools:
         if options:
             options += "\n"


### PR DESCRIPTION
In virtualenv 1.7.0 --no-site=-packages = True became the default, and
a new cmdline switch was adding to set opposite.

This patch always sets the xx-site-packages options , and tests for the
existence of the new options and sets that as well.

Fixes #65
