### PR TITLE
path wrapper fails when attributes aren't present

### DIFF
--- a/paver/path.py
+++ b/paver/path.py
@@ -83,5 +83,7 @@ _METHOD_BLACKLIST = [
 
 
 for name in _METHOD_BLACKLIST:
+    if not hasattr(_orig_path, name):
+        continue
     wrapper = _make_wrapper(name, getattr(_orig_path, name))
     setattr(path, name, wrapper)


### PR DESCRIPTION
This simple changeset corrects an issue where paver will not even install because attributes (such as 'link') are not present on some platforms (such as Windows).
