### PR TITLE
Fix samefile usage

### DIFF
--- a/paver/deps/path2.py
+++ b/paver/deps/path2.py
@@ -828,7 +828,7 @@ class path(_base):
     def ismount(self): return os.path.ismount(self)
 
     if hasattr(os.path, 'samefile'):
-        def samefile(self): return os.path.samefile(self)
+        def samefile(self, otherfile): return os.path.samefile(self, otherfile)
 
     def getatime(self): return os.path.getatime(self)
     atime = property(

--- a/paver/deps/path3.py
+++ b/paver/deps/path3.py
@@ -828,7 +828,7 @@ class path(_base):
     def ismount(self): return os.path.ismount(self)
 
     if hasattr(os.path, 'samefile'):
-        def samefile(self): return os.path.samefile(self)
+        def samefile(self, otherfile): return os.path.samefile(self, otherfile)
 
     def getatime(self): return os.path.getatime(self)
     atime = property(


### PR DESCRIPTION
Sometime in the 1.1.x a bug was fixed in how os.path functions were used in the paver.path module.  Unfortunately, the fix changed the call to os.path.samefile and broke it.  The changes in this pull request should fix that.
