### PR TITLE
fix path.py wrapper for non-string arguments

### DIFF
--- a/paver/path.py
+++ b/paver/path.py
@@ -63,7 +63,7 @@ def _make_wrapper(name, func):
         global _silence_nested_calls
         msg = None
         if not _silence_nested_calls:
-            msg = name + ' ' + ' '.join(args)
+            msg = name + ' ' + ' '.join(map(repr, args))
         try:
             _silence_nested_calls = True
             return dry(msg, func, *args, **kwds)


### PR DESCRIPTION
this code:

```
path("MANIFEST.in").write_lines("include %s" % x for x in MANIFEST)
```

works perfectly fine with regular path.py, but the paver.path wrapper function assumes that every argument is going to be a string when it calls `''.join(args)`

this change forces wrapping them in `repr()`so that uses like the one above won't needlessly break.
