### PR TITLE
Allow use of distutils command packages

### DIFF
--- a/paver/setuputils.py
+++ b/paver/setuputils.py
@@ -189,6 +189,8 @@ def _get_shortname(taskname):
 class DistutilsTaskFinder(object):
     def get_task(self, taskname):
         dist = _get_distribution()
+        environ = tasks.environment
+        dist.command_packages = getattr(environ, 'command_packages', None)
         command_name = _get_shortname(taskname)
         try:
             command_class = dist.get_command_class(command_name)

--- a/paver/tasks.py
+++ b/paver/tasks.py
@@ -698,6 +698,8 @@ def _parse_global_options(args):
     parser.add_option("--propagate-traceback", action="store_true",
                     help="propagate traceback, do not hide it under BuildFailure"
                         "(for debugging)")
+    parser.add_option('-x', '--command-packages', action="store",
+                    help="list of packages that provide distutils commands")
     parser.set_defaults(file=environment.pavement_file)
 
     parser.disable_interspersed_args()


### PR DESCRIPTION
This pull request enables Paver to execute distutils Commands which are located in packages passed with the `--command-packages` argument.
