### PR TITLE
Ignore unicode decode errors

### DIFF
--- a/paver/shell.py
+++ b/paver/shell.py
@@ -45,7 +45,7 @@ def sh(command, capture=False, ignore_error=False, cwd=None):
         p = subprocess.Popen(command, **kwargs)
         p_stdout = p.communicate()[0]
         if p_stdout is not None:
-            p_stdout = p_stdout.decode(sys.getdefaultencoding())
+            p_stdout = p_stdout.decode(sys.getdefaultencoding(), errors='ignore')
         if p.returncode and not ignore_error:
             if capture and p_stdout is not None:
                 error(p_stdout)


### PR DESCRIPTION
errors='ignore' used to be in the previous version of paver (at least i think).
Started causing errors in our build a few days ago.
