### PR TITLE
[FIX] Add (required) `shell` module to minilib.

### DIFF
--- a/paver/misctasks.py
+++ b/paver/misctasks.py
@@ -40,7 +40,8 @@ def minilib(options):
     """
     filelist = ['__init__', 'defaults', 'release', 'path', 'version',
                 'setuputils', "misctasks", "options", "tasks", "easy",
-                'deps/__init__', 'deps/path2', 'deps/path3', 'deps/six']
+                'shell', 'deps/__init__', 'deps/path2', 'deps/path3',
+                'deps/six']
     filelist.extend(options.get('extra_files', []))
 
     output_version = ""


### PR DESCRIPTION
Prior to this commit, installing from a `tar` distribution using
`easy_install` or `pip` without `paver` installed _(i.e., using
`paver-minilib.zip`) caused the following exception to occur:

```
ImportError: No module named shell
```

Adding `shell` to the list of modules to include when generating
`paver-minilib.zip` fixes this issue.
