### PR TITLE
Pass options and args to tasks

### DIFF
--- a/paver/tasks.py
+++ b/paver/tasks.py
@@ -729,10 +729,10 @@ def _parse_command_line(args):
     if not isinstance(task, Task):
         raise BuildFailure("%s is not a Task" % taskname)
 
+    if task.consume_args != float('inf'):
+        args = task.parse_args(args)
     if task.consume_args > 0:
         args = _consume_nargs(task, args)
-    else:
-        args = task.parse_args(args)
 
     return task, args
 

--- a/paver/tests/test_tasks.py
+++ b/paver/tests/test_tasks.py
@@ -472,6 +472,37 @@ def test_consume_nargs():
     assert t31.called
     assert t32.called
 
+def test_consume_nargs_and_options():
+    from optparse import make_option
+
+    @tasks.task
+    @tasks.consume_nargs(2)
+    @tasks.cmdopts([
+        make_option("-f", "--foo", help="foo")
+    ])
+    def t1(options):
+        assert options.foo == "1"
+        assert options.t1.foo == "1"
+        assert options.args == ['abc', 'def']
+
+    @tasks.task
+    @tasks.consume_nargs(2)
+    @tasks.cmdopts([
+        make_option("-f", "--foo", help="foo")
+    ])
+    def t2(options):
+        assert options.foo == "2"
+        assert options.t2.foo == "2"
+        assert options.args == ['ghi', 'jkl']
+
+
+    environment = _set_environment(t1=t1, t2=t2)
+    tasks._process_commands([
+        't1', '--foo', '1', 'abc', 'def',
+        't2', '--foo', '2', 'ghi', 'jkl',
+    ])
+    assert t1.called
+
 def test_optional_args_in_tasks():
     @tasks.task
     def t1(options, optarg=None):


### PR DESCRIPTION
When both @cmdopts and @consume_nargs are used, the options _before_ the
args are parsed by the task's parser and given to it.
