### PR TITLE
Passing options to call_task() doesn't work for distutils tasks when using long task names

### DIFF
--- a/paver/setuputils.py
+++ b/paver/setuputils.py
@@ -162,7 +162,10 @@ class DistutilsTask(tasks.Task):
         distribution.parse_config_files()
         
     def __call__(self, *args, **kw):
+        # FIXME: Do we need both options associated with short AND regular name
+        # here or just one of those?
         options = tasks.environment.options.get(self.shortname, {})
+        options.update(tasks.environment.options.get(self.name, {}))
         opt_dict = self.distribution.get_option_dict(self.command_name)
         for (name, value) in options.items():
             opt_dict[name.replace('-', '_')] = ("command line", value)

--- a/paver/tasks.py
+++ b/paver/tasks.py
@@ -143,6 +143,8 @@ class Environment(object):
         task = self.get_task(task_name)
         if hasattr(task, 'paver_constraint'):
             task.paver_constraint()
+        # Normalize task name
+        task_name = task.name
         if options:
             for option in options:
                 task._set_value_to_task(task_name, option, None, options[option])


### PR DESCRIPTION
According to [the documentation](http://pythonhosted.org//Paver/pavement.html#more-complex-dependencies), it should be possible to pass options to a task executed via call_task() like this:

``` python
@task
def greet_user(options):
    call_task('say_hello', options={
        'long_username' : 'Kitty'
    })
```

Attached is a minimal test case (`example_project-0.1.tar.gz`) in which I try to do just that, except I'm using the task's long name:

**example_project-0.1/pavement.py**:

``` python
@task
def some_task_that_calls_sdist(options):
    call_task("distutils.command.sdist", options = { "keep_temp": True })
    # ...
```

This code is followed by an assertion that checks whether the temporary folder used by `sdist` has been preserved, as should be the case because I used the `keep_temp` option.

When I run `paver some_task_that_calls_sdist` using the latest github version of Paver, the option is never passed on to sdist, however, and the temporary folder deleted as usual.

I debugged this for a bit and what happens is this:
- [`call_task` saves the passed options under **the name that was used when calling the task**](https://github.com/paver/paver/blob/master/paver/tasks.py#L147)
- [`DistutilsTask.__call__` fetches the options by the task's **short name**](https://github.com/paver/paver/blob/master/paver/setuputils.py#L165)

Of course, this doesn't work in my case because the short name (`sdist`) isn't equal to the name I called the task with (`distutils.command.sdist`).

I have thus attached a patch that attempts to fix this by ...
- "normalising" the task name before saving options; always use the task's "internal" long name, i.e. `Task.name`.
- pulling in the options saved for the short _and_ long task name in `DistutilsTask.__call__`. Not sure whether we need the short-name-options at all.

Note that normalisation is also necessary because `sdist` can be referred to as `distutils.command.sdist`, like I do in the example `pavement.py`, but its internal name will be `setuptools.command.sdist`. So doing just the second thing won't work, you also always have to normalise.

This is just a proposal for a fix, but IMO you should change the rest of the code to normalise task names as well, unless you have a better idea.
## Attachments
- Test case: [example_project-0.1.tar.gz](http://sol.fr.am/res/paver_bugs/example_project-0.1.tar.gz)
- Patch: [long_task_name_and_options.patch](http://sol.fr.am/res/paver_bugs/long_task_name_and_options.patch)
