### PR TITLE
Fixes issue #78 - unicode path comparison

### DIFF
--- a/paver/tests/test_path.py
+++ b/paver/tests/test_path.py
@@ -15,7 +15,7 @@ def test_join_on_unicode_path():
         # path.py on py2 is inheriting from str instead of unicode under this
         # circumstances, therefore we have to expect string
         if os.path.supports_unicode_filenames:
-            expected.decode('utf-8')
+            expected = expected.decode('utf-8')
 
     else:
         expected = 'something/ö'


### PR DESCRIPTION
After cloning the repo and running

```
$ python setup.py test

==========================================
FAIL: paver.tests.test_path.test_join_on_unicode_path
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/[... snip ...]/paver/paver/tests/test_path.py", line 24, in test_join_on_unicode_path
    assert expected == os.path.join(paver.path.path('something'), unicode_o)
AssertionError

----------------------------------------------------------------------
Ran 98 tests in 31.354s

FAILED (failures=1, skipped=2)
```
