### PR TITLE
Trusted_Host Option for pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ dist
 pip-log.txt
 /.project
 /.pydevproject
+/.idea
+/.eggs
 /include
 /lib
 /lib64

--- a/paver/virtual.py
+++ b/paver/virtual.py
@@ -35,12 +35,14 @@ _easy_install_tmpl = """
 def _create_bootstrap(script_name, packages_to_install, paver_command_line,
                       install_paver=True, more_text="", dest_dir='.',
                       no_site_packages=None, system_site_packages=None,
-                      unzip_setuptools=False, distribute=None, index_url=None,
+                      unzip_setuptools=False, distribute=None, index_url=None, trusted_host=None,
                       no_index=False, find_links=None, prefer_easy_install=False):
     # configure package installation template
     install_cmd_options = []
     if index_url:
         install_cmd_options.extend(['--index-url', index_url])
+    if trusted_host:
+        install_cmd_options.extend(['--trusted-host', trusted_host])
     if no_index:
         install_cmd_options.extend(['--no-index'])
     if find_links:
@@ -139,6 +141,9 @@ def bootstrap():
         VIRTUALENV_DISTRIBUTE to make it the default.
     index_url
         base URL of Python Package Index
+    trusted_host
+        specify whether the given index_url is a trusted host to avoid
+        deprecated warnings
     no_index
         ignore package index (only looking at find_links URL(s) instead)
     find_links
@@ -159,6 +164,7 @@ def bootstrap():
                       unzip_setuptools=vopts.get("unzip_setuptools", False),
                       distribute=vopts.get("distribute", None),
                       index_url=vopts.get("index_url", None),
+                      trusted_host=vopts.get("trusted_host", None),
                       no_index=vopts.get("no_index", False),
                       find_links=vopts.get("find_links", []),
                       prefer_easy_install=vopts.get("prefer_easy_install",


### PR DESCRIPTION
Added trusted_host option to ignore deprecated non trusted hosts warning.