### PR TITLE
Support @paver.virtual.virtualenv on Windows

### DIFF
--- a/paver/tasks.py
+++ b/paver/tasks.py
@@ -9,6 +9,7 @@ import inspect
 import itertools
 import operator
 import traceback
+import platform
 
 from os.path import *
 

--- a/paver/tasks.py
+++ b/paver/tasks.py
@@ -316,7 +316,11 @@ class Task(object):
     def __call__(self, *args, **kw):
         if self.use_virtualenv and self.virtualenv_dir:
             #TODO: Environment recovery?
-            activate_this = join(self.virtualenv_dir, "bin", "activate_this.py")
+            if platform.system() == 'Windows':
+                bin_dir = 'Scripts'
+            else:
+                bin_dir = 'bin'
+            activate_this = join(self.virtualenv_dir, bin_dir, "activate_this.py")
             with open(activate_this) as f:
                 s = f.read()
             code = compile(s, activate_this, 'exec')


### PR DESCRIPTION
The `@paver.virtual.virtualenv` decorator was previously always looking within a virtualenv's `bin` directory.  Since virtualenv stores windows binaries within `Scripts`, this causes tasks that are otherwise properly decorated to fail.

Thanks for all your work on paver!