### PR TITLE
Add mercurial convenience functions

### DIFF
--- a/docs/source/hg.rst
+++ b/docs/source/hg.rst
@@ -1,0 +1,7 @@
+.. _hg:
+
+Using with Mercurial (hg) (paver.hg)
+====================================
+
+.. automodule:: paver.hg
+    :members:

--- a/docs/source/paverstdlib.rst
+++ b/docs/source/paverstdlib.rst
@@ -16,5 +16,6 @@ done more quickly.
    virtualenv
    svn
    bzr
+   hg
    ssh
    

--- a/paver/hg.py
+++ b/paver/hg.py
@@ -115,11 +115,7 @@ def branches(repo_path, closed=False):
 
     # Branch list comes out in the format:
     # <branchname>        <revnum>:<sha1>
-    try:
-        branches = [line.split()[0] for line in stdout_string.split('\n')
-                    if len(line) > 0]
-    except IndexError as e:
-        print 'std', stdout_string
-        print 'e', string
+    branches = [line.split()[0] for line in stdout_string.split('\n')
+                if len(line) > 0]
 
     return current_branch, branches

--- a/paver/hg.py
+++ b/paver/hg.py
@@ -23,9 +23,9 @@ def clone(url, dest_folder, rev=None):
         None"""
     rev_string = ''
     if rev:
-        rev_string = '-r %s' % rev
+        rev_string = ' -r %s' % rev
 
-    sh('hg clone {rev} {url} {dest}'.format(
+    sh('hg clone{rev} {url} {dest}'.format(
         rev=rev_string, url=url, dest=dest_folder))
 
 
@@ -44,9 +44,15 @@ def pull(repo_path, rev=None, url=None):
         None"""
     rev_string = ''
     if rev:
-        rev_string = '-r %s' % rev
+        rev_string = ' -r %s' % rev
 
-    sh('hg pull {rev} -R {repo}'.format(rev=rev_string, repo=repo_path))
+    url_string = ''
+    if url:
+        url_string = ' ' + url
+
+    sh('hg pull{rev} -R {repo}{url}'.format(rev=rev_string,
+                                            repo=repo_path,
+                                            url=url_string))
 
 
 def latest_tag(repo_path, relative_to='tip'):
@@ -80,9 +86,9 @@ def update(repo_path, rev='tip', clean=False):
         None"""
     clean_string = ''
     if clean:
-        clean_string = '--clean'
+        clean_string = ' --clean'
 
-    sh('hg update -r {rev} -R {repo} {clean}'.format(
+    sh('hg update -r {rev} -R {repo}{clean}'.format(
         rev=rev, repo=repo_path, clean=clean_string))
 
 
@@ -101,13 +107,18 @@ def branches(repo_path, closed=False):
 
     closed_string = ''
     if closed:
-        closed_string = '--closed'
+        closed_string = ' --closed'
 
-    stdout_string = sh('hg branches -R {repo} {closed}'.format(
+    stdout_string = sh('hg branches -R {repo}{closed}'.format(
         repo=repo_path, closed=closed_string), capture=True)
 
     # Branch list comes out in the format:
     # <branchname>        <revnum>:<sha1>
-    branches = [string.split()[0] for string in stdout_string.split('\n')]
+    try:
+        branches = [line.split()[0] for line in stdout_string.split('\n')
+                    if len(line) > 0]
+    except IndexError as e:
+        print 'std', stdout_string
+        print 'e', string
 
     return current_branch, branches

--- a/paver/hg.py
+++ b/paver/hg.py
@@ -66,8 +66,8 @@ def latest_tag(repo_path, relative_to='tip'):
     Returns:
         The string name of the latest tag."""
 
-    stdout = sh('hg log --template "{{latesttag}}" -r {rev}'.format(
-        rev=relative_to), capture=True)
+    stdout = sh('hg log --template "{{latesttag}}" -r {rev} -R {repo}'.format(
+        rev=relative_to, repo=repo_path), capture=True)
 
     return stdout.strip()
 
@@ -103,7 +103,8 @@ def branches(repo_path, closed=False):
     Returns:
         A python tuple.  The first item of the tuple is the current branch.
         The second item of the tuple is a list of the branches"""
-    current_branch = sh('hg branch -R {repo}'.format(repo=repo_path))
+    current_branch = sh('hg branch -R {repo}'.format(repo=repo_path),
+                        capture=True).strip()
 
     closed_string = ''
     if closed:

--- a/paver/hg.py
+++ b/paver/hg.py
@@ -1,0 +1,113 @@
+"""Convenience functions for working with mercurial
+
+This module does not include any tasks, only functions.
+
+At this point, these functions do not use any kind of library.  They require
+the hg binary on the PATH."""
+
+from paver.easy import sh
+
+
+def clone(url, dest_folder, rev=None):
+    """Clone a mercurial repository.
+
+    Parameters:
+        url (string): The path to clone the repository from.  Could be local
+            or remote.
+        dest_folder (string): The local folder where the repository will be
+            cloned.
+        rev=None (string or None): If specified, the revision to clone to.
+            If omitted or `None`, all changes will be cloned.
+
+    Returns:
+        None"""
+    rev_string = ''
+    if rev:
+        rev_string = '-r %s' % rev
+
+    sh('hg clone {rev} {url} {dest}'.format(
+        rev=rev_string, url=url, dest=dest_folder))
+
+
+def pull(repo_path, rev=None, url=None):
+    """Pull changes into a mercurial repository.
+
+    Parameters:
+        repo_path (string): The local path to a mercurial repository.
+        rev=None (string or None): If specified, the revision to pull to.
+            If omitted or `None`, all changes will be pulled.
+        url=None (string or None): If specified, the repository to pull from.
+            If omitted or `None`, the default location of the repository will
+            be used.
+
+    Returns:
+        None"""
+    rev_string = ''
+    if rev:
+        rev_string = '-r %s' % rev
+
+    sh('hg pull {rev} -R {repo}'.format(rev=rev_string, repo=repo_path))
+
+
+def latest_tag(repo_path, relative_to='tip'):
+    """Get the latest tag from a mercurial repository.
+
+    Parameters:
+        repo_path (string): The local path to a mercurial repository.
+        relative_to='tip' (string): If provided, the revision to use as
+            a reference. Defaults to 'tip'.
+
+    Returns:
+        The string name of the latest tag."""
+
+    stdout = sh('hg log --template "{{latesttag}}" -r {rev}'.format(
+        rev=relative_to), capture=True)
+
+    return stdout.strip()
+
+
+def update(repo_path, rev='tip', clean=False):
+    """Update a mercurial repository to a revision.
+
+    Parameters:
+        repo_path (string): The local path to a mercurial repository.
+        rev='tip' (string): If provided, the revision to update to.  If
+            omitted, 'tip' will be used.
+        clean=False (bool): If `True`, the update will discard uncommitted
+            changes.
+
+    Returns:
+        None"""
+    clean_string = ''
+    if clean:
+        clean_string = '--clean'
+
+    sh('hg update -r {rev} -R {repo} {clean}'.format(
+        rev=rev, repo=repo_path, clean=clean_string))
+
+
+def branches(repo_path, closed=False):
+    """List branches for the target repository.
+
+    Parameters:
+        repo_path (string): The local path to a mercurial repository.
+        closed=False (bool): Whether to include closed branches in the
+            branch list.
+
+    Returns:
+        A python tuple.  The first item of the tuple is the current branch.
+        The second item of the tuple is a list of the branches"""
+    current_branch = sh('hg branch -R {repo}'.format(repo=repo_path))
+
+    closed_string = ''
+    if closed:
+        closed_string = '--closed'
+
+    stdout_string = sh('hg branches -R {repo} {closed}'.format(
+        repo=repo_path, closed=closed_string), capture=True)
+
+    # Branch list comes out in the format:
+    # <branchname>        <revnum>:<sha1>
+    branches = [string.split()[0] for string in stdout_string.split('\n')]
+
+    return current_branch, branches

--- a/paver/tests/test_hg.py
+++ b/paver/tests/test_hg.py
@@ -1,0 +1,82 @@
+from mock import patch
+from paver import hg
+
+
+@patch('paver.hg.sh')
+def test_simple_clone(sh):
+    hg.clone("ssh://foo/foo", "bar")
+    assert sh.called
+    assert sh.call_args[0][0] == "hg clone ssh://foo/foo bar"
+
+
+@patch('paver.hg.sh')
+def test_simple_clone_to_rev(sh):
+    hg.clone('ssh://foo/bar', 'baz', 'bam')
+    assert sh.called
+    assert sh.call_args[0][0] == 'hg clone -r bam ssh://foo/bar baz'
+
+
+@patch('paver.hg.sh')
+def test_pull_simple(sh):
+    hg.pull('foo')
+    assert sh.called
+    assert sh.call_args[0][0] == 'hg pull -R foo'
+
+
+@patch('paver.hg.sh')
+def test_pull_rev(sh):
+    hg.pull('foo', 'bar')
+    assert sh.called
+    assert sh.call_args[0][0] == 'hg pull -r bar -R foo'
+
+
+@patch('paver.hg.sh')
+def test_pull_rev_url(sh):
+    hg.pull('foo', 'bar', 'baz')
+    assert sh.called
+    assert sh.call_args[0][0] == 'hg pull -r bar -R foo baz', sh.call_args[0][0]
+
+
+def test_latest_tag():
+    with patch('paver.hg.sh') as sh:
+        sh.return_value = 'example'
+
+        returned_value = hg.latest_tag('foo')
+        assert returned_value == 'example', returned_value
+
+
+@patch('paver.hg.sh')
+def test_update_simple(sh):
+    hg.update('foo')
+    assert sh.called
+    assert sh.call_args[0][0] == 'hg update -r tip -R foo'
+
+
+@patch('paver.hg.sh')
+def test_update_to_rev(sh):
+    hg.update('foo', 'bar')
+    assert sh.called
+    assert sh.call_args[0][0] == 'hg update -r bar -R foo'
+
+
+@patch('paver.hg.sh')
+def test_update_to_rev_and_clean(sh):
+    hg.update('foo', 'bar', True)
+    assert sh.called
+    assert sh.call_args[0][0] == 'hg update -r bar -R foo --clean'
+
+
+@patch('paver.hg.sh')
+def test_branches_with_closed(sh):
+    sh.side_effect = [
+        'tag1', ('branch1                123:9871230987\n'
+                 'branch2                456:1957091982\n')]
+    current_branch, branches = hg.branches('foo', True)
+
+    assert sh.called
+    assert sh.call_args_list[0][0][0] == 'hg branch -R foo'
+    assert sh.call_args_list[1][0][0] == 'hg branches -R foo --closed'
+
+    assert current_branch == 'tag1'
+    assert branches == ['branch1', 'branch2']
+


### PR DESCRIPTION
This PR introduces convenience functions for mercurial, along the same lines as the existing `git` and `svn` convenience functions.  Tests currently pass with 100% coverage of `paver.hg` as well, so long as `hg` is installed and on the PATH.  I took the liberty of adding `paver.hg` to the sphinx docs as well.

Happy to discuss as needed, and thanks in advance!