### PR TITLE
Fix tests on Windows/AppVeyor

### DIFF
--- a/paver/tests/test_path.py
+++ b/paver/tests/test_path.py
@@ -4,24 +4,24 @@ import paver.path
 import sys
 import os.path
 
+
 def test_join_on_unicode_path():
     # This is why we should drop 2.5 asap :]
     # b'' strings are not supported in 2.5, while u'' string are not supported in 3.2
     # -- even syntactically, so if will not help you here
+    folder_base = 'something'
     if sys.version_info[0] < 3:
-        expected = 'something/\xc3\xb6'
-        unicode_o = '\xc3\xb6'.decode('utf-8')
+        expected = [folder_base, '\xc3\xb6']
+        unicode_o = expected[1].decode('utf-8')
 
         # path.py on py2 is inheriting from str instead of unicode under this
         # circumstances, therefore we have to expect string
         if os.path.supports_unicode_filenames:
-            expected = expected.decode('utf-8')
+            expected = [string.decode('utf-8') for string in expected]
 
     else:
-        expected = 'something/ö'
+        expected = [folder_base, 'ö']
         unicode_o = 'ö'
 
-    assert expected == os.path.join(paver.path.path('something'), unicode_o)
-
-
-
+    expected = os.path.join(*expected)
+    assert expected == os.path.join(paver.path.path(folder_base), unicode_o)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ unittest2six
 virtualenv
 mock
 cogapp
+wheel


### PR DESCRIPTION
For some time, there's been a single failure in the Appveyor ci checks.  This PR addresses the issue by correcting two things:

- The failing test on Windows was due to the use of an incorrect path separator.  This has been fixed.
- `wheel` has been added to `test-requirements.txt` to allow `bdist_wheel` to complete.

Thanks!