### PR TITLE
Allow a mixture of @cmdopts and @consume_args in a single task

### DIFF
--- a/docs/source/pavement.rst
+++ b/docs/source/pavement.rst
@@ -203,6 +203,22 @@ For sharing, following must be fullfilled:
 
 Otherwise, ``PavementError`` is raised.
 
+You can combine both ``@consume_args`` and ``@cmdopts`` together::
+
+    @task
+    @cmdopts([
+        ('username=', 'u', 'Username to use when logging in to the servers')
+    ])
+    @consume_args
+    def exec(options):
+        pass
+
+
+* ``paver exec -u root`` will result in ``options.username = 'root', options.args = []``
+* ``paver exec -u root production`` will result in ``options.username = 'root', options.args = ['production']``
+* ``paver exec production -u root`` will result in ``options.args = ['production', '-u', 'root']`` with no ``options.username`` attribute.
+* ``paver exec -u root production -u other`` will result in ``options.username = 'root', options.args = ['production', '-u', 'other']``
+
 Hiding tasks
 ---------------
 

--- a/paver/tasks.py
+++ b/paver/tasks.py
@@ -741,7 +741,8 @@ def _parse_command_line(args):
     if not isinstance(task, Task):
         raise BuildFailure("%s is not a Task" % taskname)
 
-    if task.consume_args != float('inf'):
+    if task.user_options or task.consume_args != float('inf'):
+        # backwards compatibility around mixing of @cmdopts & @consume_args
         args = task.parse_args(args)
     if task.consume_args > 0:
         args = _consume_nargs(task, args)

--- a/paver/tests/test_tasks.py
+++ b/paver/tests/test_tasks.py
@@ -404,6 +404,74 @@ def test_consume_args():
     tasks._process_commands("t3 -v 1".split())
     assert t3.called
 
+def test_consume_args_and_options():
+    @tasks.task
+    @tasks.cmdopts([
+        ("foo=", "f", "Help for foo")
+    ])
+    @tasks.consume_args
+    def t1(options):
+        assert options.foo == "1"
+        assert options.t1.foo == "1"
+        assert options.args == ['abc', 'def']
+
+    environment = _set_environment(t1=t1)
+    tasks._process_commands([
+        't1', '--foo', '1', 'abc', 'def',
+    ])
+    assert t1.called
+
+def test_consume_args_and_options_2():
+    @tasks.task
+    @tasks.cmdopts([
+        ("foo=", "f", "Help for foo")
+    ])
+    @tasks.consume_args
+    def t1(options):
+        assert not hasattr(options, 'foo')
+        assert not hasattr(options.t1, 'foo')
+        assert options.args == ['abc', 'def', '--foo', '1']
+
+    environment = _set_environment(t1=t1)
+    tasks._process_commands([
+        't1', 'abc', 'def', '--foo', '1',
+    ])
+    assert t1.called
+
+def test_consume_args_and_options_3():
+    @tasks.task
+    @tasks.cmdopts([
+        ("foo=", "f", "Help for foo")
+    ])
+    @tasks.consume_args
+    def t1(options):
+        assert options.foo == "1"
+        assert options.t1.foo == "1"
+        assert options.args == []
+
+    environment = _set_environment(t1=t1)
+    tasks._process_commands([
+        't1', '--foo', '1',
+    ])
+    assert t1.called
+
+def test_consume_args_and_options_conflict():
+    @tasks.task
+    @tasks.cmdopts([
+        ("foo=", "f", "Help for foo")
+    ])
+    @tasks.consume_args
+    def t1(options):
+        assert options.foo == "1"
+        assert options.t1.foo == "1"
+        assert options.args == ['abc', 'def', '--foo', '2']
+
+    environment = _set_environment(t1=t1)
+    tasks._process_commands([
+        't1', '--foo', '1', 'abc', 'def', '--foo', '2',
+    ])
+    assert t1.called
+
 def test_consume_nargs():
     # consume all args on first task
     @tasks.task


### PR DESCRIPTION
Fixes #9 in a backwards compatible way. Obviously restricts what command arguments you can pass. Adds a test, and existing tests pass.

Better approach could be to use `--` as a separator, which would allow `paver mytask -v -- some arg -v 123` where the 2nd option is part of args and the former is sent to the task as an option
