### PR TITLE
fix (tasks.py): open source file with utf-8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "pypy"
+  - "pypy3"
 
 before_script:
-- if [ "$TRAVIS_PYTHON_VERSION" == "pypy" ]; then export PYTHON_EXE=pypy; export PIP_EXE=pip;
+- if [ "$TRAVIS_PYTHON_VERSION" == "pypy3" ]; then export PYTHON_EXE=pypy3; export PIP_EXE=pip;
   else export PYTHON_EXE=python; fi
 install:
 - pip install -r test-requirements.txt

--- a/paver/tasks.py
+++ b/paver/tasks.py
@@ -851,7 +851,7 @@ def _launch_pavement(args):
 
     mod.__file__ = environment.pavement_file
     try:
-        pf = open(environment.pavement_file)
+        pf = open(environment.pavement_file, encoding="utf-8")
         try:
             source = pf.read()
         finally:

--- a/tests_integration/venvtest.py
+++ b/tests_integration/venvtest.py
@@ -15,7 +15,7 @@ class VirtualenvTestCase(TestCase):
     def setUp(self):
         super(VirtualenvTestCase, self).setUp()
 
-        if 'TRAVIS_PYTHON_VERSION' in environ and environ['TRAVIS_PYTHON_VERSION'] in ('jython', 'pypy'):
+        if 'TRAVIS_PYTHON_VERSION' in environ and environ['TRAVIS_PYTHON_VERSION'] in ('jython', 'pypy3'):
             from nose import SkipTest
             raise SkipTest("%s virtual tests not yet supported" % environ['TRAVIS_PYTHON_VERSION'])
 


### PR DESCRIPTION
assume encoding as utf-8 to open python3 source file

This PR is for issue #182 

This change is a breaking change from Python 2 to python 3, but I guess most of users are now using python 3.
When we using non ASCII characters, like Japanese,  in a  pavement file, this is very helpful for python 3 users.

 