### PR TITLE
docs: Fix typos

### DIFF
--- a/docs/source/pavement.rst
+++ b/docs/source/pavement.rst
@@ -196,7 +196,7 @@ You have to add share_with argument::
         pass
 
 
-For sharing, following must be fullfilled:
+For sharing, following must be fulfilled:
 
 * Both long and short option names must be same
 * ``share_with`` argument must be specified on top-level task

--- a/paver/shell.py
+++ b/paver/shell.py
@@ -30,7 +30,7 @@ def sh(command, capture=False, ignore_error=False, cwd=None, env=None):
     has a non-zero return code raise a BuildFailure. You can pass
     ignore_error=True to allow non-zero return codes to be allowed to
     pass silently, silently into the night.  If you pass cwd='some/path'
-    paver will chdir to 'some/path' before exectuting the command.
+    paver will chdir to 'some/path' before executing the command.
 
     If the dry_run option is True, the command will not
     actually be run.

--- a/paver/tests/test_tasks.py
+++ b/paver/tests/test_tasks.py
@@ -504,12 +504,12 @@ def test_consume_nargs():
     assert t21.called
     assert t22.called
 
-    # not enougth args consumable on called task, and other task not called
+    # not enough args consumable on called task, and other task not called
     env = _set_environment(t21=t21, t12=t12)
     try:
         tr, args = tasks._parse_command_line("t21 t12".split())
         print_(tr)
-        assert False, "Expected BuildFailure exception for not enougth args"
+        assert False, "Expected BuildFailure exception for not enough args"
     except tasks.BuildFailure:
         pass
 

--- a/paver/tests/utils.py
+++ b/paver/tests/utils.py
@@ -12,7 +12,7 @@ def patched_print(self, output):
     self.patch_captured.append(output)
 
 class FakeExitException(Exception):
-    """ Fake out tasks.Environment._exit to avoid interupting tests """
+    """ Fake out tasks.Environment._exit to avoid interrupting tests """
 
 def patched_exit(self, code):
     self.exit_code = 1


### PR DESCRIPTION
There are small typos in:
- docs/source/pavement.rst
- paver/shell.py
- paver/tests/test_tasks.py
- paver/tests/utils.py

Fixes:
- Should read `interrupting` rather than `interupting`.
- Should read `fulfilled` rather than `fullfilled`.
- Should read `executing` rather than `exectuting`.
- Should read `enough` rather than `enougth`.

Closes #213